### PR TITLE
Fix coverage collection

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ before_build:
 build_script:
  - msbuild /verbosity:quiet "codecov-on-appveyor.sln"
 test_script:
- - .\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -target:"packages\xunit.runner.console.2.2.0\tools\xunit.console.x86.exe" -targetargs:"Tests\bin\Debug\tests.dll -noshadow" -output:".\coverage.xml" -filter:"+[SystemUnderTest*]* -[Tests*]*"
+ - .\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:administrator -target:"packages\xunit.runner.console.2.2.0\tools\xunit.console.x86.exe" -targetargs:"Tests\bin\Debug\tests.dll -noshadow" -output:".\coverage.xml" -filter:"+[SystemUnderTest*]* -[Tests*]*"
 # use codecov bash script. Requires powershell and bash to be installed, which both are on the AppVeyor machine image
 after_test:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ after_test:
   - ps: |
       Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
       cat coverage.xml
+      $env:APPVEYOR="true"
+      $env:CI="true"
       bash codecov.sh -f "coverage.xml"
 # use codecov python package. Requires python to be available, which it is on AppVeyor machine image, and then we have to install the codecov package
 #after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ test_script:
 # use codecov bash script. Requires powershell and bash to be installed, which both are on the AppVeyor machine image
 after_test:
   - ps: |
-      $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
       Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
       cat coverage.xml
       bash codecov.sh -f "coverage.xml"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ after_test:
   - ps: |
       $env:PATH = 'C:\msys64\usr\bin;' + $env:PATH
       Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
+      cat coverage.xml
       bash codecov.sh -f "coverage.xml"
 # use codecov python package. Requires python to be available, which it is on AppVeyor machine image, and then we have to install the codecov package
 #after_test:


### PR DESCRIPTION
Currently I get 

> No results, this could be for a number of reasons. The most common reasons are:
    1) missing PDBs for the assemblies that match the filter please review the
    output file and refer to the Usage guide (Usage.rtf) about filters.
    2) the profiler may not be registered correctly, please refer to the Usage
    guide and the -register switch

and 

> No CI provider detected.

This PR fixes that.